### PR TITLE
Move service configuration to ConfigureServices

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -170,11 +170,11 @@ namespace SIT.WebServer
             DirectoryInfo modAssemblyDirectory = new(Path.Combine(AppContext.BaseDirectory, modAssemblyFolderName));
             IEnumerable<Assembly> modAssemblies =
                 modAssemblyDirectory.EnumerateFiles("*.dll").Select(x => Assembly.LoadFile(x.FullName));
-            Parallel.ForEach(modAssemblies, assembly =>
+            foreach (Assembly assembly in modAssemblies)
             {
                 if(!assembly.GetTypes().Any(x => x.IsSubclassOf(typeof(ControllerBase)))) return;
                 mvcBuilder.AddApplicationPart(assembly);
-            });
+            }
 
             //Services
             services.AddControllers();

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -169,10 +169,9 @@ namespace SIT.WebServer
             DirectoryInfo modAssemblyDirectory = new(Path.Combine(AppContext.BaseDirectory, modAssemblyFolderName));
             IEnumerable<Assembly> modAssemblies =
                 modAssemblyDirectory.EnumerateFiles("*.dll").Select(x => Assembly.LoadFile(x.FullName));
-            //TODO: Clean up loop body
             Parallel.ForEach(modAssemblies, assembly =>
             {
-                if(!assembly.GetTypes().Any(x => x.IsSubclassOf(typeof(ControllerBase)) || x.IsSubclassOf(typeof(Controller)))) return;
+                if(!assembly.GetTypes().Any(x => x.IsSubclassOf(typeof(ControllerBase)))) return;
                 mvcBuilder.AddApplicationPart(assembly);
             });
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -38,8 +38,6 @@ namespace SIT.WebServer
             var builder = WebApplication.CreateBuilder(args);
             ConfigureServices(builder.Services);
 
-            var app = builder.Build();
-
             // Load the Globals
             GlobalsService.Instance.LoadGlobalsIntoComfortSingleton();
             // test the singleton

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -165,7 +165,8 @@ namespace SIT.WebServer
 
             //MVC building
             IMvcBuilder mvcBuilder = services.AddMvc().AddSessionStateTempDataProvider();
-            DirectoryInfo modAssemblyDirectory = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, "Mods"));
+            const string modAssemblyFolderName = "Mods";
+            DirectoryInfo modAssemblyDirectory = new(Path.Combine(AppContext.BaseDirectory, modAssemblyFolderName));
             IEnumerable<Assembly> modAssemblies =
                 modAssemblyDirectory.EnumerateFiles("*.dll").Select(x => Assembly.LoadFile(x.FullName));
             //TODO: Clean up loop body


### PR DESCRIPTION
Moves all of `#WebApplicationBuilder.Services` configurations to it's own method for better readability and maintainability.
I've also moved all magic strings to local constants for the sake of maintainability. 

All of these changes are purely syntactic or minorly different in approach but should not affect functionality