### PR TITLE
Implement PasswordService

### DIFF
--- a/Libraries/Paulov.TarkovServices/Models/HashedPassword.cs
+++ b/Libraries/Paulov.TarkovServices/Models/HashedPassword.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Paulov.TarkovServices.Models;
+
+public readonly struct HashedPassword :  IEquatable<HashedPassword>
+{
+    public const byte CurrentPasswordVersion = 1;
+    [JsonProperty("hash")]
+    public readonly byte[] PasswordHash;
+    [JsonProperty("salt")]
+    public readonly byte[] Salt;
+    [JsonProperty("algorithm")]
+    public readonly HashAlgorithmName HashAlgorithm;
+    [JsonProperty("iterations")]
+    public readonly uint Iterations;
+    [JsonProperty("version")]
+    public readonly byte PasswordVersion = CurrentPasswordVersion; //Future-proofing
+     
+    public HashedPassword(byte[] passwordHash, byte[] salt, HashAlgorithmName hashAlgorithm, uint iterations, byte pwdVer = CurrentPasswordVersion) : this()
+    {
+        PasswordHash = passwordHash ?? throw new ArgumentNullException(nameof(passwordHash));
+        Salt = salt ?? throw new ArgumentNullException(nameof(salt));
+        HashAlgorithm = hashAlgorithm;
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(iterations, nameof(iterations));
+        Iterations = iterations;
+        PasswordVersion = pwdVer;
+    }
+
+    public override string ToString()
+    {
+        return Convert.ToHexString(PasswordHash);
+    }
+
+    public bool Equals(HashedPassword other)
+    {
+        //SequenceEqual does the heavy lifting here. It will load the values into vectors if needed
+        return PasswordHash.SequenceEqual(other.PasswordHash) && HashAlgorithm.Equals(other.HashAlgorithm) && Iterations == other.Iterations && PasswordVersion == other.PasswordVersion;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is HashedPassword other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(PasswordHash, HashAlgorithm, Iterations, PasswordVersion);
+    }
+
+    public static bool operator ==(HashedPassword left, HashedPassword right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(HashedPassword left, HashedPassword right)
+    {
+        return !(left == right);
+    }
+}

--- a/Libraries/Paulov.TarkovServices/Services/Interfaces/IPasswordService.cs
+++ b/Libraries/Paulov.TarkovServices/Services/Interfaces/IPasswordService.cs
@@ -1,0 +1,11 @@
+using Paulov.TarkovServices.Models;
+
+namespace Paulov.TarkovServices.Services;
+
+public interface IPasswordService
+{
+    void GenerateSalt(Span<byte> buffer);
+    HashedPassword GenerateSaltedHash(string password);
+    HashedPassword GenerateHashFromExistingSalt(string password, HashedPassword existingHash);
+    HashedPassword HashPassword(string password, ReadOnlySpan<byte> salt);
+}

--- a/Libraries/Paulov.TarkovServices/Services/PasswordService.cs
+++ b/Libraries/Paulov.TarkovServices/Services/PasswordService.cs
@@ -1,0 +1,64 @@
+using System.Security.Cryptography;
+using System.Text;
+using Paulov.TarkovServices.Models;
+
+namespace Paulov.TarkovServices.Services;
+
+public class PasswordService : IDisposable, IPasswordService
+{
+    private const int Pbkdf2_Iterations = 2 ^ 15;
+    private const int Pbkdf2_OutputBlockSize = 64;
+    //TODO: Make this configurable from the app configuration
+    private static readonly HashAlgorithmName Pbkdf2_HashAlgorithm = HashAlgorithmName.SHA512;
+    
+    private readonly RandomNumberGenerator _secureRNG = RandomNumberGenerator.Create(); 
+    public PasswordService()
+    {
+        
+    }
+
+    public void GenerateSalt(Span<byte> buffer)
+    {
+        _secureRNG.GetBytes(buffer);
+    }
+
+    public HashedPassword GenerateSaltedHash(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password, nameof(password));
+        //It is recommended to make the salt the same size as the output hash length
+        Span<byte> salt = stackalloc byte[Pbkdf2_OutputBlockSize];
+        _secureRNG.GetBytes(salt);
+        
+        return HashPassword(password, salt);
+    }
+
+    public HashedPassword GenerateHashFromExistingSalt(string password, HashedPassword existingHash)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password, nameof(password));
+        if(existingHash.PasswordVersion != HashedPassword.CurrentPasswordVersion) throw new InvalidOperationException("Password version mismatch.");
+        return HashPassword(password, existingHash.Salt);
+    }
+
+    public HashedPassword HashPassword(string password, ReadOnlySpan<byte> salt)
+    {
+        //I'm not allowing unicode in passwords.
+        //If someone tries to use an emoji in their password, they'll discover what their keyboard tastes like
+        Span<byte> passwordAsBytes = stackalloc byte[Encoding.ASCII.GetByteCount(password)];
+        Encoding.ASCII.GetBytes(password.AsSpan(), passwordAsBytes);
+        
+        byte[] hash = Rfc2898DeriveBytes.Pbkdf2(
+            passwordAsBytes, 
+            salt,
+            Pbkdf2_Iterations,
+            Pbkdf2_HashAlgorithm,
+            Pbkdf2_OutputBlockSize);
+
+        return new HashedPassword(hash, salt.ToArray(), Pbkdf2_HashAlgorithm, Pbkdf2_Iterations);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        _secureRNG?.Dispose();
+    }
+}

--- a/Libraries/Paulov.TarkovServices/Services/PasswordService.cs
+++ b/Libraries/Paulov.TarkovServices/Services/PasswordService.cs
@@ -6,16 +6,12 @@ namespace Paulov.TarkovServices.Services;
 
 public class PasswordService : IDisposable, IPasswordService
 {
-    private const int Pbkdf2_Iterations = 2 ^ 15;
+    private const int Pbkdf2_Iterations = 2 ^ 18;
     private const int Pbkdf2_OutputBlockSize = 64;
     //TODO: Make this configurable from the app configuration
     private static readonly HashAlgorithmName Pbkdf2_HashAlgorithm = HashAlgorithmName.SHA512;
     
-    private readonly RandomNumberGenerator _secureRNG = RandomNumberGenerator.Create(); 
-    public PasswordService()
-    {
-        
-    }
+    private readonly RandomNumberGenerator _secureRNG = RandomNumberGenerator.Create();
 
     public void GenerateSalt(Span<byte> buffer)
     {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -8,6 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Reflection;
+using Paulov.TarkovServices.Models;
 
 namespace SIT.WebServer
 {
@@ -104,8 +105,8 @@ namespace SIT.WebServer
                 .AddSession()
                 //.AddSingleton<IGlobalsService, GlobalsService>()
                 .AddSingleton<ISaveProvider, JsonFileSaveProvider>()
-                .AddSingleton<IInventoryService, InventoryService>();
-
+                .AddSingleton<IInventoryService, InventoryService>()
+                .AddSingleton<IPasswordService, PasswordService>();
 
 
 


### PR DESCRIPTION
The main goal of this PR is to implement an easy to use service that can be used to generate and compare password hashes that are secure, even from a malicious server host.

This implementation includes cryptographically secure random salts to guard against rainbow table attacks as well as the hash itself using key stretching, being a derived hash running >200,000 iterations to attempt to make brute forcing infeasible.

I have done my best to make this system future-proofed, with each hash storing a version number, allowing for identification of which standard each hash is using.

Note: Although I have implemented the ability to create new hashed passwords as well as create one from an existing instance (for comparisons) the former should **NOT** be used on the server end. All passwords should be sent to the server pre-hashed to avoid malicious server hosts from tricking clients into sending plain text passwords they believe are secure. 