### PR TITLE
Remove redundant use call

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -49,7 +49,6 @@ namespace SIT.WebServer
 
             app.UseAuthorization();
             app.UseSession(new SessionOptions() { IdleTimeout = new TimeSpan(1, 1, 1, 1) });
-            app.UseWebSockets();
 
             app.MapControllers();
 


### PR DESCRIPTION
Simply removes a redundant `UseWebSockets` call as it's already called above with options